### PR TITLE
feat: 検索機能追加

### DIFF
--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= search_form_for @q do |f| %>
   <div class='row mb-3 justify-content-center'>
     <div class='col-md-5'>
-      <%= f.search_field :title_or_body_or_user_name_or_places_name_or_tags_name_cont, class: 'form-control', placeholder: '検索ワード' %>
+      <%= f.search_field :title_or_body_or_user_name_or_places_name_or_tags_name_cont, class: 'form-control', placeholder: '検索ワード',value: params[:q].try(:[], :title_or_body_or_user_name_or_places_name_or_tags_name_cont) %>
     </div>
     <div class='col-md-1' style='display: flex; align-items: center;'>
       <%= f.submit '検索', class: 'btn form-btn search-btn' %>
@@ -11,47 +11,47 @@
     <div class='mb-3 col-lg-3'>
       タイプ：
       <%= label_tag 'post_type_eq_all', class: 'search-tag-box' do %>
-        <%= f.radio_button :post_type_eq, '', checked: true, id: 'post_type_eq_all' %>
-        <%= link_to t("enums.post.post_type.all"), { controller: "posts", action: "index", q: { post_type_eq: '' }}, class: 'search-tag' %>
+        <%= f.radio_button :post_type_eq, '', checked: (params[:q].try(:[], :post_type_eq).blank?), id: 'post_type_eq_all', onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post.post_type.all") %></p>
       <% end %>
       <%= label_tag 'post_type_eq_merchandise', class: 'search-tag-box' do %>
-        <%= f.radio_button :post_type_eq, 0, id: 'post_type_eq_merchandise' %>
-        <%= link_to t("enums.post.post_type.merchandise"), { controller: "posts", action: "index", q: { post_type_eq: 0 }}, class: 'search-tag' %>
+        <%= f.radio_button :post_type_eq, 0, id: 'post_type_eq_merchandise', checked: (params[:q].present? && params[:q][:post_type_eq].present? && params[:q][:post_type_eq].to_i == 0), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post.post_type.merchandise") %></p>
       <% end %>
       <%= label_tag 'post_type_eq_showroom', class: 'search-tag-box' do %>
-        <%= f.radio_button :post_type_eq, 1, id: 'post_type_eq_showroom' %>
-        <%= link_to t("enums.post.post_type.showroom"), { controller: "posts", action: "index", q: { post_type_eq: 1 }}, class: 'search-tag' %>
+        <%= f.radio_button :post_type_eq, 1, id: 'post_type_eq_showroom', checked: (params[:q].present? && params[:q][:post_type_eq].to_i == 1), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post.post_type.showroom") %></p>
       <% end %>
     </div>
     <div class='mb-3 col-lg-6'>
       推しポイント：
       <%= label_tag 'author_stamped_posts_all', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, '', checked: true, id: 'author_stamped_posts_all' %>
-        <%= link_to t("enums.post.post_type.all"), { controller: "posts", action: "index", q: { author_stamped_posts: '' }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, '', checked: (params[:q].try(:[], :author_stamped_posts).blank?), id: 'author_stamped_posts_all', onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post.post_type.all") %></p>
       <% end %>
       <%= label_tag 'author_stamped_posts_cute', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, 1, id: 'author_stamped_posts_cute' %>
-        <%= link_to t("enums.post_stamp.stamp.cute"), { controller: "posts", action: "index", q: { author_stamped_posts: 1 }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, 1, id: 'author_stamped_posts_cute', checked: (params[:q].present? && params[:q][:author_stamped_posts].to_i == 1), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post_stamp.stamp.cute") %></p>
       <% end %>
       <%= label_tag 'author_stamped_posts_cool', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, 2, id: 'author_stamped_posts_cool' %>
-        <%= link_to t("enums.post_stamp.stamp.cool"), { controller: "posts", action: "index", q: { author_stamped_posts: 2 }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, 2, id: 'author_stamped_posts_cool', checked: (params[:q].present? && params[:q][:author_stamped_posts].to_i == 2), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post_stamp.stamp.cool") %></p>
       <% end %>
       <%= label_tag 'author_stamped_posts_great', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, 3, id: 'author_stamped_posts_great' %>
-        <%= link_to t("enums.post_stamp.stamp.great"), { controller: "posts", action: "index", q: { author_stamped_posts: 3 }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, 3, id: 'author_stamped_posts_great', checked: (params[:q].present? && params[:q][:author_stamped_posts].to_i == 3), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post_stamp.stamp.great") %></p>
       <% end %>
       <%= label_tag 'author_stamped_posts_recommend', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, 4, id: 'author_stamped_posts_recommend' %>
-        <%= link_to t("enums.post_stamp.stamp.recommend"), { controller: "posts", action: "index", q: { author_stamped_posts: 4 }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, 4, id: 'author_stamped_posts_recommend', checked: (params[:q].present? && params[:q][:author_stamped_posts].to_i == 4), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post_stamp.stamp.recommend") %></p>
       <% end %>
       <%= label_tag 'author_stamped_posts_loved', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, 5, id: 'author_stamped_posts_loved' %>
-        <%= link_to t("enums.post_stamp.stamp.loved"), { controller: "posts", action: "index", q: { author_stamped_posts: 5 }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, 5, id: 'author_stamped_posts_loved', checked: (params[:q].present? && params[:q][:author_stamped_posts].to_i == 5), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post_stamp.stamp.loved") %></p>
       <% end %>
       <%= label_tag 'author_stamped_posts_awesome', class: 'search-tag-box' do %>
-        <%= f.radio_button :author_stamped_posts, 6, id: 'author_stamped_posts_awesome' %>
-        <%= link_to t("enums.post_stamp.stamp.awesome"), { controller: "posts", action: "index", q: { author_stamped_posts: 6 }}, class: 'search-tag' %>
+        <%= f.radio_button :author_stamped_posts, 6, id: 'author_stamped_posts_awesome', checked: (params[:q].present? && params[:q][:author_stamped_posts].to_i == 6), onclick: 'this.form.submit();' %>
+        <p class='search-tag'><%= t("enums.post_stamp.stamp.awesome") %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,7 +1,7 @@
 <%= search_form_for @q do |f| %>
   <div class='row mb-3 justify-content-center'>
     <div class='col-md-5'>
-      <%= f.search_field :title_or_body_or_user_name_or_places_name_or_tags_name_cont, class: 'form-control', placeholder: '検索ワード',value: params[:q].try(:[], :title_or_body_or_user_name_or_places_name_or_tags_name_cont) %>
+      <%= f.search_field :title_or_body_or_user_name_or_places_name_or_tags_name_cont, class: 'form-control', placeholder: '検索ワード　( ,で区切ってください )',value: params[:q].try(:[], :title_or_body_or_user_name_or_places_name_or_tags_name_cont) %>
     </div>
     <div class='col-md-1' style='display: flex; align-items: center;'>
       <%= f.submit '検索', class: 'btn form-btn search-btn' %>


### PR DESCRIPTION
グッズタイプ・推しポイントとキーワード検索を同時に行うことができるように設定。
キーワード検索は,で区切ることで複数ワードで検索可能に設定。